### PR TITLE
fix: disable provenance for github packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,3 +28,4 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           registry: "https://npm.pkg.github.com"
           access: restricted
+          provenance: false


### PR DESCRIPTION
Disables provenance for GitHub packages as this is published to a private registry