### PR TITLE
fix: quote provenance boolean

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,4 +28,4 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           registry: "https://npm.pkg.github.com"
           access: restricted
-          provenance: false
+          provenance: 'false'


### PR DESCRIPTION
Adds quotes around the provenance boolean for GitHub package publishing to parse the input correctly