### PR TITLE
fix(PostLoginEvent): make session and transaction optional

### DIFF
--- a/src/postLoginEvent.ts
+++ b/src/postLoginEvent.ts
@@ -165,10 +165,10 @@ export type PostLoginEvent = {
   request: Request;
   resource_server?: EventResourceServer;
   secrets: EventSecrets;
-  session: Session;
+  session?: Session;
   stats: EventStats;
   tenant: EventTenant;
-  transaction: EventBaseTransaction<"oidc-ciba" | "oidc-hybrid-profile"> & {
+  transaction?: EventBaseTransaction<"oidc-ciba" | "oidc-hybrid-profile"> & {
     linking_id?: string;
     requested_authorization_details?: Array<{
       type: string;


### PR DESCRIPTION
- `PostLoginEvent`: make `sesssion` and `transaction` properties optional

Reference: https://auth0.com/docs/customize/actions/explore-triggers/signup-and-login-triggers/login-trigger/post-login-event-object