### PR TITLE
chore(ci): SHA-pin third-party Actions (PTFM-18886) [skip ci]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,8 +14,8 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: '22.x'
       - run: npm ci
@@ -24,7 +24,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - run: npm pkg set publishConfig.provenance=false
-      - uses: JS-DevTools/npm-publish@v3
+      - uses: JS-DevTools/npm-publish@19c28f1ef146469e409470805ea4279d47c3d35c  # v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           registry: 'https://npm.pkg.github.com'


### PR DESCRIPTION
## Summary
SHA-pinned external GitHub Actions referenced by tag. For each `uses: foo/bar@v4`, replaced with `uses: foo/bar@<sha>  # v4`.

## Why
Tags are mutable. A compromised maintainer can re-point a tag (e.g. `v4`) to a malicious commit retroactively, even after we've reviewed and trusted the code at that tag. A SHA is immutable. The version comment keeps the line readable, and Dependabot bumps both the SHA and the comment together as new versions ship.

See [Confluence: GitHub Actions Best Practices & Recommendations / Security recommendations](https://kpler.atlassian.net/wiki/spaces/KSD/pages/243541590/GitHub+Actions+Best+Practices+Recommendations) for the rationale.

## Scope
- All `uses:` references are pinned, including internal `Kpler/*` actions. Dependabot will keep the SHA + version comment in sync as new versions ship.
- Local action references (`./...`) are not touched.
- Inline package installs (`pip install`, `uv add`, `apt install`, etc.) inside workflow scripts are intentionally OUT OF SCOPE for this PR and will be handled in a separate follow-up rollout.

## Skip-CI
Title and commit body carry `[skip ci]` so merging this PR does not trigger CI/CD on the default branch.

## Jira
[PTFM-18886](https://kpler.atlassian.net/browse/PTFM-18886)

[PTFM-18886]: https://kpler.atlassian.net/browse/PTFM-18886?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ